### PR TITLE
Update aniket-service service to 80k limit

### DIFF
--- a/alert.yaml
+++ b/alert.yaml
@@ -1335,7 +1335,7 @@ groups:
       description: Scrape sample count is {{ $value }} in container {{$labels.instance}}
         . The samples will be dropped by Prometheus as it has breached 80k sample
         limit.
-    expr: 'sum by (service,instance)(scrape_samples_post_metric_relabeling{namespace=~"production|preprod",service=~"auto-assign|auto-assign-canary|carousel-service-nav|carousel-service-nav-canary|collections-service|collections-service-canary|carousel-service-nav|carousel-service-nav-canary|dash-business-metrics-service|dash-business-metrics-service-canary"})
+    expr: 'sum by (service,instance)(scrape_samples_post_metric_relabeling{namespace=~"production|preprod",service=~"auto-assign|auto-assign-canary|carousel-service-nav|carousel-service-nav-canary|collections-service|collections-service-canary|carousel-service-nav|carousel-service-nav-canary|dash-business-metrics-service|dash-business-metrics-service-canary|aniket-service|aniket-service-canary"})
       > 80000
 
       '

--- a/app.yaml
+++ b/app.yaml
@@ -28,7 +28,7 @@ data:
         source_labels: [__meta_kubernetes_service_label_rock_io_environment]
       {{- if eq $limit 80000 }}
   - action: keep
-    regex: (auto-assign|auto-assign-canary|cdc-prod-pg-cdc-prod-pg|cdc-prod-pg-cdc-prod-pg-canary|collections-service|collections-service-canary|carousel-service-nav|carousel-service-nav-canary|dash-business-metrics-service|dash-business-metrics-service-canary)
+    regex: (auto-assign|auto-assign-canary|cdc-prod-pg-cdc-prod-pg|cdc-prod-pg-cdc-prod-pg-canary|collections-service|collections-service-canary|carousel-service-nav|carousel-service-nav-canary|dash-business-metrics-service|dash-business-metrics-service-canary|aniket-service|aniket-service-canary)
         source_labels: [__meta_kubernetes_service_label_app]
       {{- else if eq $limit 50000 }}
   - action: keep


### PR DESCRIPTION

    This PR updates the Prometheus limits for service `aniket-service` to 80k.
    
    - Updates app.yaml config template
    - Updates alert.yaml Prometheus rules
    
    Changes were made automatically by the Prometheus Config Bot.
    