### PR TITLE
Update swati-service service to 80k limit in config

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: 1.0.0
 description: A Helm chart for Application Prometheus AMP deployment
 name: prometheus-app
-version: 0.1.7
+version: 0.1.8

--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -102,7 +102,7 @@
            echo 'prometheus-system is already installed'
          fi
       - "echo 'Installing the app prometheus'"
-      - "helm pull oci://510226462375.dkr.ecr.ap-southeast-1.amazonaws.com/helm-charts/prometheus-app --version 0.1.7 --untar || echo $?"
+      - "helm pull oci://510226462375.dkr.ecr.ap-southeast-1.amazonaws.com/helm-charts/prometheus-app --version 0.1.8 --untar || echo $?"
       - |
          helm upgrade --install prometheus-app ./prometheus-app -f prometheus-app-values.yaml -n prom-amp
          kubectl apply -f amp-endpoint.yaml

--- a/config-map.yaml
+++ b/config-map.yaml
@@ -26,13 +26,13 @@ data:
       - action: keep
         regex: production
         source_labels: [__meta_kubernetes_service_label_rock_io_environment]
-      {{- if eq $limit 80000 }}
-      - action: keep
-        regex: (auto-assign|auto-assign-canary|cdc-prod-pg-cdc-prod-pg|cdc-prod-pg-cdc-prod-pg-canary|collections-service|collections-service-canary|carousel-service-nav|carousel-service-nav-canary)
+      {{- else if eq $limit 80000 }}
+  - action: keep
+    regex: (auto-assign|auto-assign-canary|cdc-prod-pg-cdc-prod-pg|cdc-prod-pg-cdc-prod-pg-canary|collections-service|collections-service-canary|carousel-service-nav|carousel-service-nav-canary|swati-service|swati-service-canary)
         source_labels: [__meta_kubernetes_service_label_app]
       {{- else if eq $limit 50000 }}
   - action: keep
-    regex: (ie-pushgateway|cdc-snowflake-sync|ie-pushgateway-canary|cdc-snowflake-sync-canary|cerebro|cerebro-canary|dash-business-metrics-service|dash-business-metrics-service-canary|collections-service|collections-service-canary|metrics-pushgateway|vidura-runtime-ads|vidura-runtime-ads-canary|core-discounting-server|core-discounting-server-canary|de-allocator|de-allocator-canary|checkout-service|confluent-lag-exporter|cerebro-listing|ads-serving-layer-rest|ads-serving-layer|ingestion-pipeline|banner|confluent-lag-exporter-canary|cerebro-listing-canary|ads-serving-layer-rest-canary|ads-serving-layer-canary|ingestion-pipeline-canary|banner-canary|del-banner-go|del-banner-go-canary|cerebro|carousel-service|carousel-service-canary|gandalf|gandalf-canary|swati-service|swati-service-canary)
+    regex: (ie-pushgateway|cdc-snowflake-sync|ie-pushgateway-canary|cdc-snowflake-sync-canary|cerebro|cerebro-canary|dash-business-metrics-service|dash-business-metrics-service-canary|collections-service|collections-service-canary|metrics-pushgateway|vidura-runtime-ads|vidura-runtime-ads-canary|core-discounting-server|core-discounting-server-canary|de-allocator|de-allocator-canary|checkout-service|confluent-lag-exporter|cerebro-listing|ads-serving-layer-rest|ads-serving-layer|ingestion-pipeline|banner|confluent-lag-exporter-canary|cerebro-listing-canary|ads-serving-layer-rest-canary|ads-serving-layer-canary|ingestion-pipeline-canary|banner-canary|del-banner-go|del-banner-go-canary|cerebro|carousel-service|carousel-service-canary|gandalf|gandalf-canary)
         source_labels: [__meta_kubernetes_service_label_app]
       {{- else if eq $limit 20000 }}
       - action: keep


### PR DESCRIPTION

    This PR updates the Prometheus config for service `swati-service` to 80k.
    Changes were made automatically by the Prometheus Config Bot.
    