### PR TITLE
Update final1801-service service to 50k limit in config

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: 1.0.0
 description: A Helm chart for Application Prometheus AMP deployment
 name: prometheus-app
-version: 0.1.20
+version: 0.1.21

--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -102,7 +102,7 @@
            echo 'prometheus-system is already installed'
          fi
       - "echo 'Installing the app prometheus'"
-      - "helm pull oci://510226462375.dkr.ecr.ap-southeast-1.amazonaws.com/helm-charts/prometheus-app --version 0.1.20 --untar || echo $?"
+      - "helm pull oci://510226462375.dkr.ecr.ap-southeast-1.amazonaws.com/helm-charts/prometheus-app --version 0.1.21 --untar || echo $?"
       - |
          helm upgrade --install prometheus-app ./prometheus-app -f prometheus-app-values.yaml -n prom-amp
          kubectl apply -f amp-endpoint.yaml

--- a/config-map.yaml
+++ b/config-map.yaml
@@ -32,7 +32,7 @@ data:
         source_labels: [__meta_kubernetes_service_label_app]
       {{- else if eq $limit 50000 }}
       - action: keep
-        regex: (ie-pushgateway|cdc-snowflake-sync|ie-pushgateway-canary|cdc-snowflake-sync-canary|cerebro|cerebro-canary|dash-business-metrics-service|dash-business-metrics-service-canary|metrics-pushgateway|vidura-runtime-ads|vidura-runtime-ads-canary|core-discounting-server|core-discounting-server-canary|de-allocator|de-allocator-canary|checkout-service|confluent-lag-exporter|cerebro-listing|ads-serving-layer-rest|ads-serving-layer|ingestion-pipeline|banner|confluent-lag-exporter-canary|cerebro-listing-canary|ads-serving-layer-rest-canary|ads-serving-layer-canary|ingestion-pipeline-canary|banner-canary|del-banner-go|del-banner-go-canary|cerebro|gandalf|gandalf-canary)
+        regex: (ie-pushgateway|cdc-snowflake-sync|ie-pushgateway-canary|cdc-snowflake-sync-canary|cerebro|cerebro-canary|dash-business-metrics-service|dash-business-metrics-service-canary|metrics-pushgateway|vidura-runtime-ads|vidura-runtime-ads-canary|core-discounting-server|core-discounting-server-canary|de-allocator|de-allocator-canary|checkout-service|confluent-lag-exporter|cerebro-listing|ads-serving-layer-rest|ads-serving-layer|ingestion-pipeline|banner|confluent-lag-exporter-canary|cerebro-listing-canary|ads-serving-layer-rest-canary|ads-serving-layer-canary|ingestion-pipeline-canary|banner-canary|del-banner-go|del-banner-go-canary|cerebro|gandalf|gandalf-canary|final1801-service|final1801-service-canary)
         source_labels: [__meta_kubernetes_service_label_app]
       {{- else if eq $limit 20000 }}
       - action: keep


### PR DESCRIPTION

    This PR updates the Prometheus config for service `final1801-service` to 50k.
    Changes were made automatically by the Prometheus Config Bot.
    